### PR TITLE
Fixed the srcweave script and added it to the install sequence

### DIFF
--- a/bin/srcweave
+++ b/bin/srcweave
@@ -1,4 +1,4 @@
-#!/usr/bin/env sbcl --script
+#!/usr/bin/env -S sbcl --script
 (load "/usr/local/lib/srcweave/bundle.lisp")
 (asdf:load-system "srcweave")
 (srcweave:toplevel)

--- a/makefile
+++ b/makefile
@@ -19,5 +19,6 @@ install:
 	mkdir -p ${PREFIX}/lib
 	./gen-script.sh ${PREFIX}
 	rsync -a --delete -r build/ "${PREFIX}/lib/srcweave/"
+	rsync -a bin/srcweave "${PREFIX}/bin/"
 	rsync -a bin/srcweave-format "${PREFIX}/bin/"
 	rsync -a bin/srcweave-format-init "${PREFIX}/bin/"


### PR DESCRIPTION
When I installed `srcweave` the main script wasn't copied to `/usr/local/bin` so I added that to the `makefile`.

Also, I got this error when I first ran it:
```
/usr/bin/env: ‘sbcl --script’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```
So I added the `-S` and it worked. Hopefully that doesn't break anything.