### PR TITLE
Add escape @@{...} functionality

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 DIR=build/local-projects/srcweave
-PREFIX=/usr/local
+PREFIX?=/usr/local
 BUNDLE=${PREFIX}/lib/bundle.lisp
 
 SRC_LISP=$(wildcard *.lisp)

--- a/parse.lisp
+++ b/parse.lisp
@@ -32,16 +32,16 @@
 
 (defparameter *ref-pattern*
   (ppcre:create-scanner '(:SEQUENCE
-                          #\@ #\{
-                          (:REGISTER (:GREEDY-REPETITION 1 nil
-                                      (:INVERTED-CHAR-CLASS #\})))
+                          (:NEGATIVE-LOOKBEHIND #\@)
+                          "@{"
+                          (:REGISTER (:GREEDY-REPETITION 1 NIL (:INVERTED-CHAR-CLASS #\})))
                           #\})))
 
 (defun parse-refs (line)
   (let ((parts (ppcre:split *ref-pattern* line :with-registers-p t)))
     (mapcar-indexed (lambda (string i)
                       (if (evenp i)
-                          string
+                          (ppcre:regex-replace-all "@@({[^}]+})" string "@\\1")
                           (list :INCLUDE string)))
                     parts)))
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -8,3 +8,4 @@ google-code-prettify
 katex
 styles
 *.timestamp
+*.lisp

--- a/tests/basic/basic.lit
+++ b/tests/basic/basic.lit
@@ -220,5 +220,14 @@ int boring_function()
 But, you will notice it does not appear in the documentation.
 References to @{/hidden.c} will not have references.
 
+## Escaping the include syntax "@{...}"
 
+In code blocks and prose, the @ sign followed by an open and close brace is typically parsed as a code block reference. You can use a double @ sign to escape from that functionality. When weaving/tangling, the double "@@@" gets replaced by a single "@".
 
+--- Escape-includes
+(defvar includes-regex "@@{\\(\w+\\)}")
+---
+
+--- /escaped.lisp
+@{Escape-includes}
+---

--- a/tests/basic/escaped.lisp.expected
+++ b/tests/basic/escaped.lisp.expected
@@ -1,0 +1,1 @@
+(defvar includes-regex "@{\\(\w+\\)}")


### PR DESCRIPTION
I ran into an issue where the text "...@{...}..." inside of prose or
code blocks would get treated as a reference to a code block when I
didn't want it to.

In my case, I was just trying to define a regular expression.

Also adds support custom PREFIX for install so that you can
install this in a user local directory.

I haven't spent any time considering the performance implications of the additional 
negative lookbehind and the regex-replace-all on each line.