### PR TITLE
Better error message non missing block

### DIFF
--- a/tangle.lisp
+++ b/tangle.lisp
@@ -39,7 +39,10 @@
   (dolist (id sorted-id-list)
     (multiple-value-bind (block present)
         (gethash id block-table)
-      (assert present)
+      (when (not present)
+        (error 'user-error
+         :format-control "attempting to include unknown block ~s"
+         :format-arguments (list id)))
       (setf (gethash id block-table)
             (textblock-include block block-table)))))
  


### PR DESCRIPTION
Instead of outputting a backtrace and no reference to the name of the block that's missing, just
print the error message that includes the name
of the missing block. Makes it easier to track down typos and forgotton code blocks.

Aligns with what's in [weave.lisp](https://github.com/justinmeiners/srcweave/blob/master/weave.lisp#L70).